### PR TITLE
Eliminate need to manually switch env params

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [ 12.x ]
 
     steps:
 
@@ -34,6 +34,9 @@ jobs:
 
       - name: Build page
         run: npm run build
+        env:
+          - REACT_APP_GOOGLE_API_KEY: ${{ secrets.REACT_APP_GOOGLE_API_KEY }}
+          - REACT_APP_GOOGLE_CLIENT_ID: ${{ secrets.REACT_APP_GOOGLE_CLIENT_ID }}
 
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [ 12.x ]
 
     steps:
 
@@ -37,3 +37,6 @@ jobs:
 
       - name: Build page
         run: npm run build
+        env:
+          - REACT_APP_GOOGLE_API_KEY: ${{ secrets.REACT_APP_GOOGLE_API_KEY }}
+          - REACT_APP_GOOGLE_CLIENT_ID: ${{ secrets.REACT_APP_GOOGLE_CLIENT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# local dev environment variables
+/.env
+
 # dependencies
 /node_modules
 /.pnp

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ by [Outright Mental](https://outrightmental.com/)<sup>&trade;</sup>
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Environment
+
+These environment variables must be set in order to build and run the app. This can by creating an **.env** file in the root of the project, which will be ignored by git-- secrets should Never be checked in to the repository:
+
+```shell
+REACT_APP_GOOGLE_API_KEY=ABC
+REACT_APP_GOOGLE_CLIENT_ID=123
+```
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,8 @@
   <link rel="icon" href="%PUBLIC_URL%/favicon.ico"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="theme-color" content="#000000"/>
+  <meta name="REACT_APP_GOOGLE_API_KEY" content="%REACT_APP_GOOGLE_API_KEY%"/>
+  <meta name="REACT_APP_GOOGLE_CLIENT_ID" content="%REACT_APP_GOOGLE_CLIENT_ID%"/>
   <script src="https://apis.google.com/js/api.js" async defer></script>
   <meta
     name="description"

--- a/src/config.js
+++ b/src/config.js
@@ -1,12 +1,8 @@
 export const
 
-  GOOGLE_API_KEY =
-    'AIzaSyDMeOHdQ7sRjWwmK4pXBsL8KPDXYXEyOdw', //Production
-    // 'AIzaSyDGMNlKWChcdRnm06FaAPl5qSJzM8_9XFY', // Development
+  GOOGLE_API_KEY = readMetaTag('REACT_APP_GOOGLE_API_KEY'),
 
-  GOOGLE_CLIENT_ID =
-    '716546716200-k27gns7n7emjglrn2bec5jui3323r0ua.apps.googleusercontent.com', // Production
-    // '307271403290-nirg6c5afjm47qtlloufj0kgrfd05ui7.apps.googleusercontent.com', // Development
+  GOOGLE_CLIENT_ID = readMetaTag('REACT_APP_GOOGLE_CLIENT_ID'),
 
   GOOGLE_SCOPE = [
     "https://www.googleapis.com/auth/calendar.events.readonly",
@@ -29,3 +25,10 @@ export const
   CACHE_INVALIDATE_MILLIS = 1000 * 60 * 60,
 
   CALENDAR_FETCH_ROWS_MAX = 999;
+
+function readMetaTag(name) {
+  let el = document.head.querySelector(`[name=${name}][content]`);
+  if (el && el.content) return el.content;
+  console.error("Cannot retrieve value for META tag named", name);
+  return "n/a";
+}


### PR DESCRIPTION
Resolves #12

Ignore local development .env parameters

Read value of environment variables on build time and write html META tags to be read on config time:
  - REACT_APP_GOOGLE_API_KEY
  - REACT_APP_GOOGLE_CLIENT_ID