### PR TITLE
Exit fullscreen graceful failure

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -124,10 +124,11 @@ class App extends Component {
     if (document.exitFullscreen)
       document.exitFullscreen().then(
         () => {
-          this.setState({isFullscreen: false})
+          this.setState({isFullscreen: false});
         },
         () => {
-          alert("Failed to close fullscreen mode!");
+          // quietly assume that we have failed to detect somehow that fullscreen was already exited
+          this.setState({isFullscreen: false});
         }
       );
     else alert("Fullscreen mode not supported in your browser!");


### PR DESCRIPTION
Resolves #25

User opens fullscreen mode, then something else on the device exits fullscreen mode, and we fail to detect it. Failure to exit fullscreen mode should not create alert and fail. It should gracefully assume that we have made a mistake, and quietly set the app state back to `isFullscreen: false`