### PR TITLE
Update _palette.scss

### DIFF
--- a/src/Event.scss
+++ b/src/Event.scss
@@ -37,6 +37,7 @@
   .header {
     display: flex;
     flex-direction: row;
+    margin-bottom: 0.38rem;
 
     .date-time {
       text-align: right;
@@ -56,6 +57,7 @@
     display: flex;
     flex-direction: row;
     align-content: center;
+    margin-bottom: 0.38rem;
 
     .summary {
       text-align: center;

--- a/src/_palette.scss
+++ b/src/_palette.scss
@@ -31,6 +31,10 @@ $ready-bg-color: darken($bright-yellow, 25%);
 $go-color: $bright-green;
 $go-bg-color: darken($bright-green, 25%);
 
+body {
+  background: #000000;
+}  
+
 @mixin body_background() {
   background: #000000;
   background: radial-gradient(ellipse at center, #202020 0%, #000000 200%);


### PR DESCRIPTION
- BODY has background of #000000 visible for example in Android when browser scrolls past screen
- Margin below calendar event time header and content itself, for better appearance after testing on Android Galaxy Tab A